### PR TITLE
 Fix client freeze caused by arrows stuck in players

### DIFF
--- a/src/main/java/org/fentanylsolutions/wawelauth/mixins/early/minecraft/MixinModelBiped.java
+++ b/src/main/java/org/fentanylsolutions/wawelauth/mixins/early/minecraft/MixinModelBiped.java
@@ -1,8 +1,5 @@
 package org.fentanylsolutions.wawelauth.mixins.early.minecraft;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import net.minecraft.client.model.ModelBase;
@@ -126,19 +123,17 @@ public abstract class MixinModelBiped extends ModelBase implements IModelBipedMo
         this.bipedBody.addBox(-4.0F, 0.0F, -2.0F, 8, 12, 4, scale);
 
         this.remapUV(bipedRightArm, 40, 16);
-
+        this.bipedRightArm.addBox(0.0F, 0.0F, 0.0F, 1, 1, 1, 0.0F);
         this.classicRightArm = new ModelRenderer(self, 40, 16);
         this.classicRightArm.addBox(-3.0F, -2.0F, -2.0F, 4, 12, 4, scale);
-
         this.slimRightArm = new ModelRenderer(self, 40, 16);
         this.slimRightArm.addBox(-2.0F, -2.0F, -2.0F, 3, 12, 4, scale);
         this.slimRightArm.setRotationPoint(0.0F, 0.5F, 0.0F);
 
         this.remapUV(bipedLeftArm, 32, 48);
-
+        this.bipedLeftArm.addBox(0.0F, 0.0F, 0.0F, 1, 1, 1, 0.0F);
         this.classicLeftArm = new ModelRenderer(self, 32, 48);
         this.classicLeftArm.addBox(-1.0F, -2.0F, -2.0F, 4, 12, 4, scale);
-
         this.slimLeftArm = new ModelRenderer(self, 32, 48);
         this.slimLeftArm.addBox(-1.0F, -2.0F, -2.0F, 3, 12, 4, scale);
         this.slimLeftArm.setRotationPoint(0.0F, 0.5F, 0.0F);
@@ -159,14 +154,12 @@ public abstract class MixinModelBiped extends ModelBase implements IModelBipedMo
 
         this.classicRightArmWear = new ModelRenderer(self, 40, 32);
         this.classicRightArmWear.addBox(-3.0F, -2.0F, -2.0F, 4, 12, 4, scale + overlay);
-
         this.slimRightArmWear = new ModelRenderer(self, 40, 32);
         this.slimRightArmWear.addBox(-2.0F, -2.0F, -2.0F, 3, 12, 4, scale + overlay);
         this.slimRightArmWear.setRotationPoint(0.0F, 0.5F, 0.0F);
 
         this.classicLeftArmWear = new ModelRenderer(self, 48, 48);
         this.classicLeftArmWear.addBox(-1.0F, -2.0F, -2.0F, 4, 12, 4, scale + overlay);
-
         this.slimLeftArmWear = new ModelRenderer(self, 48, 48);
         this.slimLeftArmWear.addBox(-1.0F, -2.0F, -2.0F, 3, 12, 4, scale + overlay);
         this.slimLeftArmWear.setRotationPoint(0.0F, 0.5F, 0.0F);
@@ -201,12 +194,9 @@ public abstract class MixinModelBiped extends ModelBase implements IModelBipedMo
     @Override
     public void setSlim(boolean slim) {
         if (!this.modernEnabled) return;
-
         this.currentSlim = slim;
-
         this.classicRightArm.showModel = !slim;
         this.classicLeftArm.showModel = !slim;
-
         this.slimRightArm.showModel = slim;
         this.slimLeftArm.showModel = slim;
     }
@@ -492,22 +482,6 @@ public abstract class MixinModelBiped extends ModelBase implements IModelBipedMo
     @Override
     public ModelRenderer getLeftLegWear() {
         return this.leftLegWear;
-    }
-
-    @Override
-    public ModelRenderer getRandomModelBox(Random random) {
-        List<ModelRenderer> validParts = new ArrayList<>();
-        for (ModelRenderer mr : this.boxList) {
-            if (mr.cubeList != null && !mr.cubeList.isEmpty() && mr.showModel) {
-                validParts.add(mr);
-            }
-        }
-        if (validParts.isEmpty()) {
-            ModelRenderer dummy = new ModelRenderer(this);
-            dummy.addBox(0, 0, 0, 1, 1, 1);
-            return dummy;
-        }
-        return validParts.get(random.nextInt(validParts.size()));
     }
 
 }

--- a/src/main/java/org/fentanylsolutions/wawelauth/mixins/early/minecraft/MixinModelBiped.java
+++ b/src/main/java/org/fentanylsolutions/wawelauth/mixins/early/minecraft/MixinModelBiped.java
@@ -1,5 +1,8 @@
 package org.fentanylsolutions.wawelauth.mixins.early.minecraft;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import net.minecraft.client.model.ModelBase;
@@ -489,6 +492,22 @@ public abstract class MixinModelBiped extends ModelBase implements IModelBipedMo
     @Override
     public ModelRenderer getLeftLegWear() {
         return this.leftLegWear;
+    }
+
+    @Override
+    public ModelRenderer getRandomModelBox(Random random) {
+        List<ModelRenderer> validParts = new ArrayList<>();
+        for (ModelRenderer mr : this.boxList) {
+            if (mr.cubeList != null && !mr.cubeList.isEmpty() && mr.showModel) {
+                validParts.add(mr);
+            }
+        }
+        if (validParts.isEmpty()) {
+            ModelRenderer dummy = new ModelRenderer(this);
+            dummy.addBox(0, 0, 0, 1, 1, 1);
+            return dummy;
+        }
+        return validParts.get(random.nextInt(validParts.size()));
     }
 
 }


### PR DESCRIPTION
Currently, when `modernSkinSupport` is enabled, rendering arrows stuck in a modern-skinned player's arms (`bipedRightArm` or `bipedLeftArm`) triggers a repeating `java.lang.IllegalArgumentException: bound must be positive` error, causing rendering issues or client freezes.
This PR fixes the issue by overriding `ModelBase.getRandomModelBox` to filter out bones that do not contain any boxes. If no valid bones are found, it fallback to a dummy bone containing a default box, ensuring the bound parameter for `nextInt` is always positive.
Full crash report：
```
[20:24:02] [Client thread/ERROR]: Couldn't render entity
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.Random.nextInt(Random.java:551) ~[?:?]
	at Launch//net.minecraft.client.renderer.entity.RendererLivingEntity.func_85093_e(RendererLivingEntity.java:371) ~[boh.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderPlayer.func_77029_c(RenderPlayer.java:176) ~[bop.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderPlayer.func_77029_c(RenderPlayer.java:496) ~[bop.class:?]
	at Launch//net.minecraft.client.renderer.entity.RendererLivingEntity.func_76986_a(RendererLivingEntity.java:213) [boh.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderPlayer.func_76986_a(RenderPlayer.java:158) [bop.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderPlayer.func_76986_a(RenderPlayer.java:521) [bop.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderManager.mixinextras$bridge$func_76986_a$16(RenderManager.java) [bnn.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderManager.wrapOperation$zhm000$angelica$iris$wrapDoRender(RenderManager.java:534) [bnn.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderManager.func_147939_a(RenderManager.java:293) [bnn.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderManager.func_147936_a(RenderManager.java:271) [bnn.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderManager.func_147937_a(RenderManager.java:244) [bnn.class:?]
	at Launch//net.minecraft.client.renderer.RenderGlobal.mixinextras$bridge$func_147937_a$97(RenderGlobal.java) [bma.class:?]
	at Launch//net.minecraft.client.renderer.RenderGlobal.wrapOperation$zha000$angelica$renderEntitySimple(RenderGlobal.java:5603) [bma.class:?]
	at Launch//net.minecraft.client.renderer.RenderGlobal.func_147589_a(RenderGlobal.java:471) [bma.class:?]
	at Launch//net.minecraft.client.renderer.EntityRenderer.func_78471_a(EntityRenderer.java:1224) [blt.class:?]
	at Launch//net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1011) [blt.class:?]
	at Launch//net.minecraft.client.Minecraft.redirect$zcc000$angelica$skipRenderWhenIconified(Minecraft.java:4951) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:17505) [bao.class:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) [Launch.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) [forgePatches-f0fd6617a5b12865b3dbe6590e61008ed77fe5123733422bfeadef93a838aa3a.jar:3.0.25]
	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47) [forgePatches-f0fd6617a5b12865b3dbe6590e61008ed77fe5123733422bfeadef93a838aa3a.jar:3.0.25]
	at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]
```